### PR TITLE
Use python 3.13 with Docker image instead of python 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && \
       git wget ca-certificates git build-essential libssl-dev zlib1g-dev \
       libbz2-dev libreadline-dev libsqlite3-dev libffi-dev libxml2-dev \
       libxslt1-dev libre2-dev pkg-config && \
-    pip3 install --no-binary lxml --upgrade git+https://github.com/ngie-eign/grab-site && \
+    pip3 install --no-binary lxml --upgrade git+https://github.com/ngie-eign/grab-site@py313-support && \
     apt-get purge -y \
 			git build-essential pkg-config && \
     apt-get autoremove -y && apt-get clean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM python:3.8-slim
+FROM python:3.13-slim
 
 RUN apt-get update && \
 	apt-get install --no-install-recommends -y \
       git wget ca-certificates git build-essential libssl-dev zlib1g-dev \
       libbz2-dev libreadline-dev libsqlite3-dev libffi-dev libxml2-dev \
       libxslt1-dev libre2-dev pkg-config && \
-    pip3 install --no-binary lxml --upgrade git+https://github.com/ArchiveTeam/grab-site && \
+    pip3 install --no-binary lxml --upgrade git+https://github.com/ngie-eign/grab-site && \
     apt-get purge -y \
-			git build-essential pkg-config && \ 
+			git build-essential pkg-config && \
     apt-get autoremove -y && apt-get clean && \
     rm -rf /var/lib/apt/lists/* /var/tmp/* /tmp/*
 


### PR DESCRIPTION
python 3.8 has been EOLed since last September. Switch to Python 3.13 since (as of writing) it is the most modern supported version of Python.
Depends on https://github.com/ArchiveTeam/grab-site/pull/249.